### PR TITLE
Add some more links to the docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,25 +2,28 @@
 
 > noop functions to help formatters and syntax highlighters recognize embedded code
 
-By marking your embedded code with one of these functions, [Prettier](https://prettier.io/docs/en/options.html#embedded-language-formatting) and syntax highlighters will recognize a string as a piece of code to format or highlight. You can see that GitHub also correctly highlights HTML within javascript as long as it uses the tag:
+When embedding other languages in JavaScript, you can mark those strings with a [tag function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) to help JavaScript tools recognize the string as code:
 
 ```js
 document.body.innerHTML = html`
-	<!-- Uses the tag        👆 -->
-	<p>Highlighted HTML in JS 🙂</p>
-	<style>
-		.and {
-			css: 'too';
-		}
-	</style>
-`;
-
-document.body.innerHTML = `
-	<!-- No tag             👆 -->
-	<p>Just HTML in JS 😕</p>
-	<style>.and {raw: 'css'}</style>
+	<p>This is inline HTML</p>
+	<!-- Including comments -->
+	<style>.and {css: 'too'}</style>
 `;
 ```
+
+You can find such tag functions in:
+
+- **code-tag**: this package, it returns the string as is
+- [lit-html](https://lit.dev/docs/templates/overview/): it helps write Web Components
+- [Apollo](https://www.apollographql.com/docs/resources/graphql-glossary/#gql-function): it parses GraphQL strings
+- [Emotion](https://emotion.sh/docs/@emotion/css): it defines CSS-in-JS
+- etc…
+
+Here are some tools that support them natively:
+
+- [Prettier](https://prettier.io/docs/en/options.html#embedded-language-formatting): it formats the strings as real non-JavaScript code
+- GitHub: it highlights the syntax in the strings as code (as seen in the example above)
 
 ## Install
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > noop functions to help formatters and syntax highlighters recognize embedded code
 
-By marking your embedded code with one of these functions, Prettier and syntax highlighters will recognize a string as a piece of code to format or highlight. You can see that GitHub also correctly highlights HTML within javascript as long as it uses the tag
+By marking your embedded code with one of these functions, [Prettier](https://prettier.io/docs/en/options.html#embedded-language-formatting) and syntax highlighters will recognize a string as a piece of code to format or highlight. You can see that GitHub also correctly highlights HTML within javascript as long as it uses the tag:
 
 ```js
 document.body.innerHTML = html`


### PR DESCRIPTION
Also maybe:

- [x] Other libraries that use such tags, like:
	- [ ]  https://github.com/apollographql/graphql-tag#fragments
	- [ ] https://lit.dev/docs/api/templates/