### PR TITLE
Add `sql` tag

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -20,4 +20,5 @@ export {
 	any as graphql,
 	any as md,
 	any as markdown,
+	any as sql,
 };

--- a/readme.md
+++ b/readme.md
@@ -31,9 +31,9 @@ npm install code-tag
 ## Usage
 
 ```js
-import {html, css, gql, md} from 'code-tag';
+import {html, css, gql, md, sql} from 'code-tag';
 // Or:
-// const {html, css, gql, md} = require('code-tag');
+// const {html, css, gql, md, sql} = require('code-tag');
 
 document.body.innerHTML = html`
 	<p>This is HTML in JS</p>
@@ -58,6 +58,8 @@ yourMarkdownConverter(md`
 
 	Is _highlighted_ [as well](https://www.youtube.com/watch?v=dQw4w9WgXcQ)
 `);
+
+await sqlQuery(sql`select * from users`);
 ```
 
 There's also an `any` export that you can rename as you please:

--- a/test.mjs
+++ b/test.mjs
@@ -11,13 +11,14 @@ const cjs = require('./dist/index.js');
 testContext(cjs, 'cjs');
 testContext(esm, 'esm');
 
-function testContext({any, html, css, gql, md}, name) {
+function testContext({any, html, css, gql, md, sql}, name) {
 	describe(name + ' imports', () => {
 		it('exports', () => {
 			assert.equal(any, html);
 			assert.equal(any, css);
 			assert.equal(any, gql);
 			assert.equal(any, md);
+			assert.equal(any, sql);
 		});
 
 		it('code-tags', () => {


### PR DESCRIPTION
There are [extensions](https://marketplace.visualstudio.com/items?itemName=frigus02.vscode-sql-tagged-template-literals) that support highlighting SQL queries inside other code via `sql` tag. There are also eslint plugins that even lint SQL queries → https://github.com/gajus/eslint-plugin-sql.