### PR TITLE
Drop microbundle

### DIFF
--- a/.github/workflows/esm-lint.yml
+++ b/.github/workflows/esm-lint.yml
@@ -77,7 +77,7 @@ jobs:
     needs: Pack
     steps:
       - uses: actions/download-artifact@v3
-      - run: npm install ./artifact
+      - run: npm install ./artifact && npm install -g @types/estree
       - run: echo "${{ env.IMPORT_TEXT }} '${{ env.NPM_MODULE_NAME }}'" > index.ts
       - run: tsc index.ts
       - run: cat index.js

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ logs
 *.map
 index.js
 index.d.ts
-dist
+!esm/package.json

--- a/esm/package.json
+++ b/esm/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/package.json
+++ b/package.json
@@ -22,28 +22,27 @@
 	"license": "MIT",
 	"author": "Federico Brigante <me@fregante.com> (https://fregante.com)",
 	"exports": {
-		"require": "./dist/index.js",
-		"types": "./dist/index.d.ts",
-		"default": "./dist/index.mjs"
+		"require": "./cjs/index.js",
+		"types": "./cjs/index.d.ts",
+		"default": "./esm/index.js"
 	},
-	"main": "dist/index.js",
-	"module": "dist/index.mjs",
-	"source": "index.ts",
-	"types": "dist/index.d.ts",
+	"main": "cjs/index.js",
+	"module": "esm/index.js",
+	"types": "cjs/index.d.ts",
 	"files": [
-		"dist",
-		"index.ts"
+		"cjs",
+		"esm"
 	],
 	"scripts": {
-		"build": "microbundle --no-compress --no-sourcemap --format esm,cjs",
+		"build": "tsc && tsc --outDir cjs --module commonjs",
 		"prepack": "npm run build",
 		"test": "xo && npm run build && node --test",
-		"watch": "npm run build -- --watch"
+		"watch": "tsc --watch"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^3.0.1",
 		"@types/estree": "^1.0.0",
-		"microbundle": "^0.15.0",
+		"typescript": "^4.7.4",
 		"xo": "^0.49.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^3.0.1",
-		"@types/estree": "^1.0.0",
 		"typescript": "^4.7.4",
 		"xo": "^0.49.0"
 	}

--- a/test.mjs
+++ b/test.mjs
@@ -3,10 +3,10 @@ import {createRequire} from 'node:module';
 import {describe, it} from 'node:test';
 
 // The tests specifically import the built files to ensure that they're generated correctly
-import * as esm from './dist/index.mjs';
+import * as esm from './esm/index.js';
 
 const require = createRequire(import.meta.url);
-const cjs = require('./dist/index.js');
+const cjs = require('./cjs/index.js');
 
 testContext(cjs, 'cjs');
 testContext(esm, 'esm');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
 	"extends": "@sindresorhus/tsconfig",
 	"compilerOptions": {
-		"outDir": "."
+		"module": "es2020",
+		"outDir": "esm"
 	},
 	"files": [
 		"index.ts"


### PR DESCRIPTION
I was using microbundle hoping it would simplify config by just reading the fields from package.json, but in practice this:

- unnecessarily transpiled down to ES5
- did not type-check
- added 327 dev-dependencies
- did not save much config **at all** (it did however allow creating .mjs files)

Why am I using a build at all?

- d.ts is never out of sync
- I want to offer both cjs and esm so it's broadly available