### PR TITLE
Return raw string in most common scenario (i.e. no replacements )

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@
 const concatenateTemplateLiteralTag = (
 	raw: TemplateStringsArray,
 	...keys: string[]
-): string => String.raw({raw}, ...keys);
+): string => keys.length === 0 ? raw[0] : String.raw({raw}, ...keys);
 
 /**
 Enable highlighting/prettifying when used as html`<div>` or css`.a {}`

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@
 const concatenateTemplateLiteralTag = (
 	raw: TemplateStringsArray,
 	...keys: string[]
-): string => keys.length === 0 ? raw[0] : String.raw({raw}, ...keys);
+): string => keys.length === 0 ? raw[0]! : String.raw({raw}, ...keys);
 
 /**
 Enable highlighting/prettifying when used as html`<div>` or css`.a {}`

--- a/test.mjs
+++ b/test.mjs
@@ -25,8 +25,10 @@ function testContext({any, html, css, gql, md, sql}, name) {
 			assert.equal(any`a`, 'a');
 			assert.equal(any` a `, ' a ', 'Preserve boundary whitespace');
 			assert.equal(any`a${'b'}c${1}`, 'abc1', 'Interpolate with strings and numbers');
-			assert.equal(any`\\\na${'\\\na'}`, '\\\na\\\na', 'Preserve escape sequences');
-			assert.equal(any`🇪🇺 ${'🇺🇳'}`, '🇪🇺 🇺🇳', 'Preserve combined emojis');
+			assert.equal(any`\\\na\\\na`, '\\\na\\\na', 'Preserve escape sequences');
+			assert.equal(any`\\\na${'\\\na'}`, '\\\na\\\na', 'Preserve escape sequences in interpolation');
+			assert.equal(any`🇪🇺 🇺🇳`, '🇪🇺 🇺🇳', 'Preserve combined emojis');
+			assert.equal(any`🇪🇺 ${'🇺🇳'}`, '🇪🇺 🇺🇳', 'Preserve combined emojis in interpolation');
 		});
 
 		it('stringifiable objects', () => {


### PR DESCRIPTION
Since `code-tag` _does nothing_ at runtime, I thought I'd optimize this _nothing_ by skipping the `String.raw` call when used without replacements: <code>html\`\<a\>\`</code>